### PR TITLE
feat: replace URL-path wine detection with name-based keyword filter for okwine

### DIFF
--- a/frontend/src/app/components/wine-rating-badge/wine-rating-badge.component.html
+++ b/frontend/src/app/components/wine-rating-badge/wine-rating-badge.component.html
@@ -1,5 +1,5 @@
 @if (wineRating()) {
-  <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 5px;" [style.opacity]="isLowConfidence() ? '0.5' : '1'">
+  <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 5px;">
     <svg viewBox="0 0 36 36" style="height: 30px; width: 30px;" [style.stroke]="badgeColor()">
         <path style="fill: none; stroke: #eee; stroke-width: 3.8;" d="M18 2.0845
           a 15.9155 15.9155 0 0 1 0 31.831

--- a/frontend/src/app/components/wine-rating-badge/wine-rating-badge.component.ts
+++ b/frontend/src/app/components/wine-rating-badge/wine-rating-badge.component.ts
@@ -35,7 +35,7 @@ export class WineRatingBadgeComponent {
 
   @HostBinding('style')
   get hostStyles() {
-    return { ...this.styles(), opacity: this.isLowConfidence() ? '0.5' : '1' };
+    return { ...this.styles()};
   }
 
   @HostListener('click', ['$event'])

--- a/frontend/src/app/services/okwine.service.ts
+++ b/frontend/src/app/services/okwine.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { EMPTY, from, Observable, of, Subject, forkJoin } from 'rxjs';
 import { delay, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { isOkWineWineDepartment } from '../shared/utils/store.util';
+import { isWineProductName } from '../shared/utils/store.util';
 import { VIVINO_BAGE_CLASS, WINE_RESIDUES_CLASS } from '../app.constants';
 import { OkWineInternalData } from '../models/okwine';
 import { Message } from '../models/message';
@@ -10,6 +10,8 @@ import { WineResiduesQuery } from '../models/wine-residues-query';
 import { normalizeWineName } from '../shared/utils/wine-name.util';
 import { WineStoreService } from './contract/wine-store-service';
 import { BadgeService } from './badge.service';
+
+const LOG_PREFIX = '[OKWINE]';
 
 @Injectable({
   providedIn: 'root',
@@ -37,9 +39,11 @@ export class OkwineService implements WineStoreService {
   }
 
   private addRatings(delayMs: number, tableSelector: string): Observable<void> {
-    if (!isOkWineWineDepartment()) return EMPTY;
+    const wineItems = this.getWineListItems()
+      .filter((wineItem) => !wineItem.querySelector(`.${VIVINO_BAGE_CLASS}`))
+      .filter((wineItem) => isWineProductName(this.getRawWineName(wineItem)));
 
-    const wineItems = this.getWineListItems().filter((wineItem) => !wineItem.querySelector(`.${VIVINO_BAGE_CLASS}`));
+    if (!wineItems.length) return EMPTY;
 
     return of(null).pipe(
       delay(delayMs),
@@ -48,8 +52,8 @@ export class OkwineService implements WineStoreService {
           settings: this.settingsService.get('okwineSettings'),
           winesInternalData: this.getWinesInternalData(tableSelector),
         }).pipe(tap((data) => {
-          if (!data.winesInternalData.length) {
-            console.warn('OkWine internal data is empty');
+          if (!data.winesInternalData?.length) {
+            console.log(LOG_PREFIX, 'internal data is empty');
           }
         })),
       ),
@@ -83,7 +87,7 @@ export class OkwineService implements WineStoreService {
   private getWinesInternalData(selector: string): Observable<OkWineInternalData[]> {
     return new Observable((observer) => {
       chrome.runtime.sendMessage<Message>({ type: 'GetOkwineInternalData', selector }, (response: OkWineInternalData[]) => {
-        observer.next(response);
+        observer.next(response ?? []);
         observer.complete();
       });
     });
@@ -93,10 +97,13 @@ export class OkwineService implements WineStoreService {
     return Array.from(document.querySelectorAll(this.WINE_ITEM_CONTAINER_SELECTOR));
   }
 
-  private getWineName(wineItem: Element): string {
+  private getRawWineName(wineItem: Element): string {
     const links = wineItem.querySelectorAll('a');
-    const wineTitle = links.item(links.length - 1)?.firstChild?.textContent?.trim() ?? '';
-    return normalizeWineName(wineTitle);
+    return links.item(links.length - 1)?.firstChild?.textContent?.trim() ?? '';
+  }
+
+  private getWineName(wineItem: Element): string {
+    return normalizeWineName(this.getRawWineName(wineItem));
   }
 
   private addRatingBadge(wineItem: Element, internalData?: OkWineInternalData): void {

--- a/frontend/src/app/shared/utils/store.util.ts
+++ b/frontend/src/app/shared/utils/store.util.ts
@@ -46,6 +46,22 @@ export const isOkWineWineDepartment = (): boolean => {
   return winePaths.some((path) => window.location.pathname.includes(path));
 };
 
+const wineNameKeywords = [
+  'вино', 'вина', 'вермут', 'ігристе', 'игристое', 'шампанське',
+  'просеко', 'портвейн', 'мадера', 'херес', 'сидр', 'саке',
+  'мартіні', 'martini', 'столове', 'молоде', 'кріплене', 'десертне',
+  'виноградне', 'бургундське', 'бордо',
+  'wine', 'cava', 'chardonnay', 'cabernet', 'merlot', 'pinot',
+  'sauvignon', 'riesling', 'malbec', 'syrah', 'rose',
+  'піно', 'rouge', 'blanc',
+];
+
+export const isWineProductName = (title: string): boolean => {
+  if (!title) return false;
+  const lower = title.toLowerCase();
+  return wineNameKeywords.some((kw) => lower.includes(kw));
+};
+
 export const isRozetkaWineDepartment = (): boolean => {
   return window.location.host.includes(Host.Rozetka) && window.location.pathname.includes('vino');
 };


### PR DESCRIPTION
## Summary

Replaces URL-path-based wine department detection (`isOkWineWineDepartment`) with per-item name-based keyword matching for okwine.ua. The extension now activates on any page that has product containers, but only adds badges to items whose name contains wine-related keywords.

## Problem

- URL-path matching (`vina`, `vino`, `-wine`) missed many pages with wine items: `/ua/action`, `/ua/sobstvennyy-import`, `/ua/mini-i-magnumy`, `/ua/somelye-rekomenduye`, collection pages
- Patterns would break when okwine changes URL structure
- `normalizeWineName()` returned non-empty names for non-wine items (whiskey, gin, snacks) causing wasteful API calls
- Internal data response could be null, causing crashes on homepage

## Changes

**`store.util.ts`**
- Added `isWineProductName()` — checks product title against wine-related keywords:
  - Wine types in Ukrainian: `вино`, `вина`, `вермут`, `ігристе`, `шампанське`, `просеко`, `портвейн`, `мадера`, `херес`, `сидр`, `саке`, `мартіні`, `столове`, `молоде`, `кріплене`, `десертне`, `виноградне`, `бургундське`, `бордо`
  - Grape varieties in Latin: `chardonnay`, `cabernet`, `merlot`, `pinot`, `sauvignon`, `riesling`, `malbec`, `syrah`
  - French wine terms: `rouge`, `blanc`
  - Ukrainian Pinot/Pineau: `піно`
  - English/Western: `wine`, `cava`, `rose`, `martini`

**`okwine.service.ts`**
- Removed `isOkWineWineDepartment()` gate and its import
- Added name-based filter before processing each product item
- Early `EMPTY` return when no items pass the name filter (saves settings fetch + internal data extraction)
- `observer.next(response ?? [])` — handles null/undefined from background script
- `data.winesInternalData?.length` — optional chaining to prevent null crash
- Extracted `getRawWineName()` helper (raw title) from `getWineName()` (normalized)
- Changed `console.warn` to `console.log` with `LOG_PREFIX = '[OKWINE]'` constant

## New detection flow

1. Page loads → find `[data-testid="integrationProductContainer"]` elements
2. For each item: check raw title against `isWineProductName()`
3. If no items match → return early, no work done
4. If items match → fetch settings + internal data, add badges
5. `normalizeWineName()` still acts as secondary gate inside `addRatingBadge()`